### PR TITLE
RestDocs 세팅 및 Product API를 문서화 한다.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,6 @@ plugins {
     id 'org.asciidoctor.convert' version '2.4.0'
 }
 
-sourceCompatibility = '1.8'
-
 configurations {
     developmentOnly
     runtimeClasspath {
@@ -99,12 +97,51 @@ application {
     mainClass = 'com.codesoom.assignment.App'
 }
 
-tasks.named('test') {
+ext {
+    // Test 스니펫 문서들의 저장 위치를 설정합니다.
+    set('snippetsDir', file("build/generated-snippets"))
+}
+
+test {
     // Use junit platform for unit tests.
     useJUnitPlatform()
+
+    // `snippetsDir로 설정한 디렉토리에 Test 스니펫을 생성합니다.
+    outputs.dir snippetsDir
 }
 
 asciidoctor {
-    // asciidoctor는 test에 의존한다.
+    // .adoc 파일에서 다른 .adoc을 include하여 사용할 경우 동일한 경로를 baseDir로 설정합니다.
+    // gradle 6.x 버전에서는 자동으로 설정해줌
+//    baseDirFollowsSourceFile()
+
+    // `snippetsDir로 설정한 디렉토리를 input 디렉토리로 설정
+    inputs.dir snippetsDir
+
+    // asciidoctor는 test에 의존합니다.
     dependsOn test
+}
+
+asciidoctor.doFirst {
+    // asciidoctor가 실행될 때 먼저 이전 파일 삭제를 진행합니다.
+    delete file('src/main/resources/static/docs')
+}
+
+// gradle 빌드 시 from에 생성된 docs 파일을 into 경로에 복사합니다.
+task createDocument(type: Copy) {
+    // createDocumnet는 asciidoctor에 의존합니다.
+    dependsOn asciidoctor
+
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static")
+}
+
+bootJar {
+    // bootJar는 createDocument에 의존합니다.
+    dependsOn createDocument
+
+    // gradle 빌드 시 outputDir에 HTML 파일이 생기고, 이것을 jar 안에 /resource/static 폴더에 복사합니다.
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/app/src/docs/asciidoc/index.adoc
+++ b/app/src/docs/asciidoc/index.adoc
@@ -1,17 +1,8 @@
-= 고양이 장난감 가게 API
+:doctype: book
+:toc: left
+:toclevels: 2
+:sectlinks:
 
-== GET /products
 
-상품 목록을 JSON 형태로 돌려준다.
 
-include::{snippets}/get-products/http-request.adoc[]
-
-include::{snippets}/get-products/http-response.adoc[]
-
-== GET /product/{id}
-
-상품에 대한 자세한 정보를 JSON 형태로 돌려준다.
-
-include::{snippets}/get-product/http-request.adoc[]
-
-include::{snippets}/get-product/http-response.adoc[]
+include::product.adoc[]

--- a/app/src/docs/asciidoc/product.adoc
+++ b/app/src/docs/asciidoc/product.adoc
@@ -1,0 +1,78 @@
+[[Product]]
+= Product API
+
+
+== 상품 목록 조회
+
+=== GET /products
+상품 목록을 JSON 형태로 돌려준다.
+
+operation::get-products[snippets='http-request,http-response']
+
+operation::get-products[snippets= 'response-fields']
+
+&#160;
+
+== 상품 단일 상세 조회
+
+=== GET /product
+상품에 대한 자세한 정보를 JSON 형태로 돌려준다.
+
+
+operation::get-product[snippets='path-parameters']
+
+&#160;
+
+operation::get-product[snippets='http-request,http-response']
+
+&#160;
+
+operation::get-product[snippets= 'response-fields']
+
+&#160;
+
+== 상품 정보 등록
+
+=== POST /product
+상품을 등록하고, 등록된 정보를 JSON 형태로 돌려준다.
+
+operation::create-product[snippets='request-body,request-fields']
+
+&#160;
+
+operation::create-product[snippets='http-request,http-response']
+
+&#160;
+
+operation::create-product[snippets= 'response-fields']
+
+&#160;
+
+== 상품 정보 수정
+
+=== PATCH /product
+상품을 수정하고, 수정된 정보를 JSON 형태로 돌려준다.
+
+operation::update-product[snippets='path-parameters']
+
+&#160;
+
+operation::update-product[snippets='request-body,request-fields']
+
+&#160;
+
+operation::update-product[snippets='http-request,http-response']
+
+&#160;
+
+== 상품 정보 삭제
+
+=== DELETE /product
+상품을 삭제한다.
+
+
+operation::delete-product[snippets='path-parameters']
+
+&#160;
+
+operation::delete-product[snippets='http-request,http-response']

--- a/app/src/main/java/com/codesoom/assignment/product/adapter/in/web/dto/request/ProductCreateRequestDto.java
+++ b/app/src/main/java/com/codesoom/assignment/product/adapter/in/web/dto/request/ProductCreateRequestDto.java
@@ -3,9 +3,11 @@ package com.codesoom.assignment.product.adapter.in.web.dto.request;
 import com.codesoom.assignment.product.application.port.command.ProductCreateRequest;
 import com.codesoom.assignment.product.application.port.command.ProductMapper;
 import com.codesoom.assignment.product.domain.Product;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -13,6 +15,7 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 @EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductCreateRequestDto implements ProductCreateRequest {
 
     @NotBlank(message = "이름을 입력하세요")

--- a/app/src/main/java/com/codesoom/assignment/product/adapter/in/web/dto/request/ProductUpdateRequestDto.java
+++ b/app/src/main/java/com/codesoom/assignment/product/adapter/in/web/dto/request/ProductUpdateRequestDto.java
@@ -3,9 +3,11 @@ package com.codesoom.assignment.product.adapter.in.web.dto.request;
 import com.codesoom.assignment.product.application.port.command.ProductMapper;
 import com.codesoom.assignment.product.application.port.command.ProductUpdateRequest;
 import com.codesoom.assignment.product.domain.Product;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -13,6 +15,7 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 @EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductUpdateRequestDto implements ProductUpdateRequest {
 
     @NotBlank(message = "이름을 입력하세요")

--- a/app/src/test/java/com/codesoom/assignment/presentation/RestDocsMockMvcProvider.java
+++ b/app/src/test/java/com/codesoom/assignment/presentation/RestDocsMockMvcProvider.java
@@ -1,0 +1,49 @@
+package com.codesoom.assignment.presentation;
+
+import com.codesoom.assignment.MockMvcCharacterEncodingCustomizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.Filter;
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+/**
+ * MockMvc을 설정하여 제공하는 객체입니다. <br>
+ * 해당 객체를 상속 받을 경우 `@WebMvcTest` 혹은 `@SpringBootTest`를 통해 WebApplicationContext를 제공해야됩니다.
+ */
+@Import(MockMvcCharacterEncodingCustomizer.class)
+@ExtendWith({RestDocumentationExtension.class})
+public class RestDocsMockMvcProvider {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private Filter springSecurityFilterChain;
+
+    @BeforeEach
+    void setUpMockMvc(final RestDocumentationContextProvider restDcosContextProvider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDcosContextProvider))
+                // Spring Security 필터 체인을 주입합니다.
+                .addFilter(springSecurityFilterChain)
+                // 테스트의 결과 값을 UTF-8로 설정해줍니다.
+                // (Spring Boot 2.2부터는 Spring에서 charset을 사용하지 않고 기본 인코딩 문자도 더 이상 UTF-8이 아닙니다.)
+                // Ref: https://github.com/spring-projects/spring-framework/issues/22788
+                .alwaysDo(result -> result.getResponse().setCharacterEncoding(StandardCharsets.UTF_8.name()))
+                .alwaysDo(print())
+                .build();
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/utils/ApiDocumentUtil.java
+++ b/app/src/test/java/com/codesoom/assignment/utils/ApiDocumentUtil.java
@@ -1,0 +1,27 @@
+package com.codesoom.assignment.utils;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+public interface ApiDocumentUtil {
+    static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                // 문서 상의 기본 uri 값인 localhost:8080을 변경해줍니다.
+                modifyUris()
+                        .scheme("https")
+                        .host("docs.api.com")
+                        .removePort(),
+                // 문서의 request의 json 포맷을 예쁘게 정렬합니다.
+                prettyPrint());
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse() {
+        // 문서의 response의 json 포맷을 예쁘게 정렬합니다.
+        return preprocessResponse(prettyPrint());
+    }
+}


### PR DESCRIPTION
## 개요
- RestDocs 환경을 구축한다.
- Product 관련 API를 RestDocs를 통해 문서화한다.

## 작업 요약
- RestDocs 환경을 세팅합니다.
- Product 목록 조회 API를 문서화합니다.
- Product 상세 조회 API를 문서화합니다.
- Product 등록 API를 문서화합니다.
- Product 수정 API를 문서화합니다.
- Product 삭제 API를 문서화합니다.

## 작업 내용
- [x] RestDocs 환경 구축
- [x] RestDocs에 필요한 유틸 생성
- [x] ProductController 웹 테스트에서 asciidoc 스니펫 생성 작업
- [x] Product API 문서화

<br>

## 참고 자료

![image](https://user-images.githubusercontent.com/59248326/205281543-7d8835a6-b360-4b27-8b3d-850ba0256f20.png)

