### PR TITLE
도메인 엔티티의 기본키 생성을 데이터베이스로 위임한다

### DIFF
--- a/app/src/main/java/com/codesoom/assignment/product/domain/Product.java
+++ b/app/src/main/java/com/codesoom/assignment/product/domain/Product.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
@@ -16,7 +17,7 @@ import javax.persistence.Id;
 @EqualsAndHashCode
 public class Product {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/app/src/main/java/com/codesoom/assignment/role/domain/Role.java
+++ b/app/src/main/java/com/codesoom/assignment/role/domain/Role.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
@@ -15,7 +16,7 @@ import javax.persistence.Id;
 @EqualsAndHashCode
 public class Role {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Long userId;

--- a/app/src/main/java/com/codesoom/assignment/user/domain/User.java
+++ b/app/src/main/java/com/codesoom/assignment/user/domain/User.java
@@ -7,6 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
@@ -14,7 +15,7 @@ import javax.persistence.Id;
 @EqualsAndHashCode
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;


### PR DESCRIPTION
## 개요
- Entity의 id가 2씩 증가하는 현상 발생

## 작업 요약
- 도메인 엔티티의 기본키 생성을 데이터베이스로 위임합니다.

## 작업 내용

- [x] 각 엔티티의 id의 generationType을 identity로 설정한다

<br>

## 참고 자료

